### PR TITLE
enhance: support for tab key in webclient

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -22,9 +22,28 @@ const onInput = () => {
 textarea.addEventListener('input', onInput);
 onInput();
 
+const indent = (spaces = 4) => {
+    let cursorPosition = textarea.selectionStart;
+    const before = textarea.value.substring(0, cursorPosition);
+    const after = textarea.value.substring(cursorPosition, textarea.value.length);
+
+    // add 4 spaces
+    textarea.value = before + ' '.repeat(spaces) + after;
+    cursorPosition += spaces;
+
+    // place the cursor accordingly
+    textarea.selectionStart = cursorPosition;
+    textarea.selectionEnd = cursorPosition;
+    textarea.focus();
+}
+
 document.body.addEventListener('keydown', (e) => {
     if (e.key === 'Enter' && e.ctrlKey) {
         form.submit();
+    }
+    if (e.key === 'Tab' && !e.ctrlKey) {
+        preventDefaults(e);
+        indent();
     }
 });
 


### PR DESCRIPTION
As mentioned in #8, I added support for the tab key.

It adds 4 spaces, not the tab character. Maybe that's not the most appropriate way.

We could improve that even more:
* it adds 4 spaces but removes on space at a time with delete key
* you can't indent a block of code

I forked from `master` but opened the merge request on `next`, so it includes your commit "bin v2.2.0". If that's not what you want, let me know.