### PR TITLE
Fix typo: pretter -> pretty

### DIFF
--- a/src/routes/pretty_retrieve.rs
+++ b/src/routes/pretty_retrieve.rs
@@ -14,7 +14,7 @@ use crate::models::response_wrapper::ResponseWrapper;
 
 #[get("/p/<id>", rank = 2)]
 pub async fn pretty_retrieve(id: PasteId<'_>) -> ResponseWrapper<Template> {
-    pretter_retrieve_inner(&id.to_string(), "txt").await
+    pretty_retrieve_inner(&id.to_string(), "txt").await
 }
 
 #[get("/p/<id_ext>", rank = 1)]
@@ -24,10 +24,10 @@ pub async fn pretty_retrieve_ext(
     let id = id_ext.get_fname();
     let ext = id_ext.get_ext();
 
-    pretter_retrieve_inner(id, ext).await
+    pretty_retrieve_inner(id, ext).await
 }
 
-pub async fn pretter_retrieve_inner(
+pub async fn pretty_retrieve_inner(
     id: &str,
     ext: &str,
 ) -> ResponseWrapper<Template> {


### PR DESCRIPTION
Just fix a typo

---


- [x] Cargo Format
    - Run `cargo fmt` on the project.
    
- [x] Clippy lints
    - Run `cargo clippy -- -Dwarnings` on the project to check for suggestions
    - Run `cargo clippy --fix` to let clippy apply the suggestions itself, if any.
